### PR TITLE
added missing spilling option

### DIFF
--- a/3-nodes-mirror-3-dc-olap/files/dynamic-config.yaml
+++ b/3-nodes-mirror-3-dc-olap/files/dynamic-config.yaml
@@ -111,6 +111,7 @@ selector_config:
         sql_version: 1
         enable_olap_sink: true
         enable_spilling_nodes: "All"
+        enable_query_service_spilling: true
         spilling_service_config:
           local_file_config:
             enable: true


### PR DESCRIPTION
`enable_query_service_spilling` is missing in the config with enabled spilling